### PR TITLE
Babel 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
   },
   "author": "Jorge Bucaran",
   "dependencies": {
+    "babel-core": "^6.3.21",
+    "babel-preset-es2015": "^6.3.13",
     "object-assign": "^3.0.0",
-    "babel-core": "*",
     "source-map": "^0.4.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrade to v6.
Include es2015 preset by default (99% of the reason why people choose babel anyway)

Solves [#120](https://github.com/bucaran/fly/issues/120)