### PR TITLE
Rewind & Patch in 0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fly-babel",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Babel plugin for Fly",
   "license": "MIT",
   "repository": "https://github.com/bucaran/fly-babel",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   },
   "author": "Jorge Bucaran",
   "dependencies": {
+    "babel-core": "^5.8.29",
     "object-assign": "^3.0.0",
-    "babel-core": "*",
     "source-map": "^0.4.4"
   },
   "devDependencies": {


### PR DESCRIPTION
We need to patch in 0.6.1 before upgrading to Babel6 as `0.7.0`

This should work:

```
git clone https://github.com/bucaran/fly-babel.git
cd fly-babel
git reset 9b2243fbe8206237313f9ce149d15eb369811c99 --hard
git push origin +master
```

This undos my recent PR & makes the latest commit message `0.6.0`.

Then merge this PR.

Then publish v0.6.1 to npm. `npm publish`

Then re-merge in my previous PR #3 

Lastly, update the `package.json` file to `0.7.1` and republish to npm.


#### Why?

The unspecified `babel-core: *` is pulling in Babel 6.3, which breaks Fly (using Babel 5.8)